### PR TITLE
Fix typo in CG1 docstring

### DIFF
--- a/HCM/CG1.py
+++ b/HCM/CG1.py
@@ -61,7 +61,7 @@ class CG1:
     save_graph:
         save and store chunking graph
     add_chunk:
-    check_ancenstry:
+    check_ancestry:
         check the ancestors of a specific chunk
     forget:
         decay the count frequency by a factor


### PR DESCRIPTION
## Summary
- correct comment for `check_ancestry` in `CG1` class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68524a50406c832b94384a8516a7171a